### PR TITLE
Add run-export on itself

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705
 
 build:
-  number: 0
+  number: 1
   skip: win
   script:
     - ./configure --prefix=${{ PREFIX }}
@@ -24,6 +24,8 @@ requirements:
     - make
     - if: osx
       then: gawk
+  run_exports:
+    - ${{ pin_subpackage('hyphen', exact=True) }}
 
 tests:
   - package_contents:


### PR DESCRIPTION
Since hyphen provides a shared library it needs to have a run export on itself so that the shared library is then also available during runtime

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
